### PR TITLE
/weather som en endpoint istället

### DIFF
--- a/backend/api/api.js
+++ b/backend/api/api.js
@@ -2,7 +2,7 @@ import { usersHandler } from "./users/users-api.js";
 import { listHandler } from "./lists/list-api.js";
 import { imageHandler } from "./unsplash/imageApi.js";
 
-function handler(req) {
+async function handler(req) {
     let url = new URL(req.url);
 
     if(url.pathname.startsWith("/users")) {
@@ -19,6 +19,18 @@ function handler(req) {
         let imageResponse = imageHandler(req);
         if(imageResponse) return imageResponse;
     }
+
+    if(url.pathname == "/weather") {
+        const apiKeysFile = await Deno.readTextFile("../../apiKeys.json");
+        const keys = JSON.parse(apiKeysFile);
+        const API_KEY_WEATHER = keys[0].API_KEY_WEATHER; 
+        const BASE_URL = "https://api.weatherstack.com/current";
+        let body = await req.json();
+        let res = await fetch(`${BASE_URL}?access_key=${API_KEY_WEATHER}&query=${encodeURIComponent(body.city)}`);
+        let data = await res.json();
+        return new Response(JSON.stringify(data), { headers: { "Access-Control-Allow-Origin": "*", "content-type": "application/json" } })
+    } 
+
     return null
 }
 

--- a/frontend/client/weater-client.js
+++ b/frontend/client/weater-client.js
@@ -357,11 +357,7 @@ const weatherDB = [
 ]
 
 // === LÄS IN API-KEY FÖR ONLINE-LÄGE ===
-/* const apiKeysFile = await Deno.readTextFile("../../../apiKeys.json");
-const keys = JSON.parse(apiKeysFile);
-const API_KEY_WEATHER = keys[0].API_KEY_WEATHER; 
-
-const BASE_URL = "https://api.weatherstack.com/current"; */
+/* Görs nu i api.js, eftersom det är backends jobb! */
 
 
 // === SKA FINNAS FÖR BÅDE OFFLINE & ONLINE!
@@ -374,8 +370,6 @@ class WeatherData {
         this.weatherDescriptions = weatherDescriptions;
     }
 }
-
-
 
 export async function getWeatherDataFunc (city) {
     
@@ -408,10 +402,10 @@ export async function getWeatherDataFunc (city) {
     // === ONLINE-LÄGE ===
     // KOMMENTERA IN DETTA BLOCK FÖR ONLINE:
     /*
-    const url = `${BASE_URL}?access_key=${API_KEY_WEATHER}&query=${encodeURIComponent(city)}`; // måste ha "encodeURIComponent" för att servern ska kunna koda av parametern korrekt!
+    const url = `http://localhost:8000/weather`; 
     console.log("🔵 Online request URL:", url);
 
-    const response = await fetch(url);
+    let response = await fetch(url, {method: "POST", body: JSON.stringify({city: ${city})});
     const weatherObject = await response.json();
 
     const weather = new WeatherData(

--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
             </div>
 
             <div class="header-container-right">
-                <img class="header-container-right-img" src="/assets/icons/addIcon.png" alt="Add new list" />
                 <img class="header-container-right-img user-profile" src="/assets/icons/user2.png" alt="User profile" />
             </div>
 


### PR DESCRIPTION
Detta är för att apikeys brukar hanteras i backend och inte i frontend, man kan ta ut keyn i backend med deno.readtextfile. Nu är det som vi skickar en request till vår egna endpoint (api.js) och sen i den skickar till väder apiet som en post, problemet är att min väder api key var tydligen false och fungera inte, så om någon annan vill fortsätta som har  access till rätt nyckel feel free!