### PR TITLE
Error hantering på imageApi.js

### DIFF
--- a/backend/api/unsplash/imageApi.js
+++ b/backend/api/unsplash/imageApi.js
@@ -1,22 +1,34 @@
 export async function imageHandler(req) {
   const reqUrl = new URL(req.url);
   const corsHeaders = {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
   };
 
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 200, headers: corsHeaders });
   }
 
-  if(req.method == "POST" && reqUrl.pathname == "/image/randomimage") {
+  if (req.method == "POST" && reqUrl.pathname == "/image/randomimage") {
     let body = await req.json();
+    if (!body.content) {
+      return new Response(JSON.stringify({ error: "Bild måste anges" }), {
+        status: 400,
+        headers: {...corsHeaders,"content-type": "application/json" }
+      });
+    }
     const imagesDB = await readImages();
-    if(!imagesDB.images[body.content]) imagesDB.images[body.content] = []; // lägg till om ej finns
+    if (!imagesDB.images[body.content]) imagesDB.images[body.content] = []; // lägg till om ej finns
     let randomImage = await getRandomImage(body.content);
     imagesDB.ratelimit = randomImage.ratelimit;
-    if(randomImage.url == null) {
+    if (randomImage.url == null) {
+      if(!imagesDB.images[body.content] || imagesDB.images[body.content].length == 0){ //om ej finns eller längden på listan är 0
+          return new Response(JSON.stringify({ error: "Bild kunde inte hämtas" }), {
+          status: 404,
+          headers: {...corsHeaders,"content-type": "application/json" }
+        });
+      }
       randomImage.url = imagesDB.images[body.content][Math.floor(Math.random() * imagesDB.images[body.content].length)];
     } else {
       imagesDB.images[body.content].push(randomImage.url);
@@ -53,11 +65,11 @@ async function getRandomImage(content) {
   let images = await readImages();
   result.ratelimit = images.ratelimit;
   let timeDiff = Date.now() - result.ratelimit.lastChecked;
-  if(result.ratelimit.remaining >= 25 || timeDiff >= 1000*60*60) {
+  if (result.ratelimit.remaining >= 25 || timeDiff >= 1000 * 60 * 60) {
     const response = await fetch(`https://api.unsplash.com/photos/random?query=${content}&content_filter=high&client_id=${ACCESS_KEY}`);
     result.ratelimit.remaining = response.headers.get("X-Ratelimit-Remaining");
     result.ratelimit.lastChecked = Date.now();
-    if(response.status == 200) {
+    if (response.status == 200) {
       const data = await response.json();
       result.url = data.urls.small;
     }


### PR DESCRIPTION
Måste hantera vissa errors;

**POST 400**: ifall du skickar in {} (tomt, eller ej rätt format) ska "bild måste anges" komma som response.
**POST 404**: Ifall man skickar in ett valid objekt _(t ex {content:”spain”})_ fast man kunde inte komma åt det externa unsplash apiet och det fanns aldrig någon bild man kunde ta från databasen sen innan.


